### PR TITLE
Fixed syntax highlighting for templ methods

### DIFF
--- a/syntax/templ.vim
+++ b/syntax/templ.vim
@@ -27,7 +27,7 @@ unlet b:current_syntax
 
 " templ
 syn match templTemplateDec    /^templ/ nextgroup=templReceiverDecl,templFunction skipwhite skipnl
-syn match templReceiverDecl      /(\s*\zs\%(\%(\w\+\s\+\)\?\*\?\w\+\%(\[\%(\%(\[\]\)\?\w\+\%(,\s*\)\?\)\+\]\)\?\)\ze\s*)/ contained contains=goReceiverVar,goReceiverType,goPointerOperator nextgroup=templFunction skipwhite skipnl
+syn match templReceiverDecl      /(\s*\%(\w\+\s\+\)\?\*\?\s*\w\+\%(\[\%(\%(\[\]\)\?\w\+\%(,\s*\)\?\)\+\]\)\?\s*)\ze\s*\w/ contained contains=goReceiverVar,goReceiverType,goPointerOperator nextgroup=templFunction skipwhite skipnl
 syn match templFunction          /\w\+/ nextgroup=templSimpleParams,templTypeParams contained skipwhite skipnl
 syn match templSimpleParams      /(\%(\w\|\_s\|[*\.\[\],\{\}<>-]\)*)/ contained contains=goParamName,goType nextgroup=templTemplateBlock skipwhite skipnl
 syn match templTypeParams        /\[\%(\w\+\s\+\%(\~\?\%(\[]\)\?\w\%(\w\||\)\)*\%(,\s*\)\?\)\+\]/ nextgroup=templSimpleParams contained skipwhite skipnl


### PR DESCRIPTION
This fixes #8 .

I believe that this code was originally based on the go.vim syntax highlighting.
However, the wrong regexp was copied for the methods, as it seems the original `goReceiverDecl` matches the arguments of a method only, while `goReceiver` matches the receiver itself. 

I fixed it by replacing the regexp, and now both functions and methods are properly highlighted.

Source for the regexp: https://github.com/sheerun/vim-polyglot/blob/master/syntax/go.vim#L338:L354